### PR TITLE
added `stairs` dependency

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,5 @@
 default
+stairs?
 cannabis 
 3d_armor?
 pipeworks?

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,4 @@
+name = summer
+description = Adds summer items.
+depends = default, cannabis
+optional_depends = stairs, 3d_armor, pipeworks


### PR DESCRIPTION
Without `stairs` being loaded, `granite.lua` fails because of missing
global `stairs` in line 29.